### PR TITLE
Robotpony merge

### DIFF
--- a/lib/api.php
+++ b/lib/api.php
@@ -80,7 +80,7 @@ class API extends REST {
 		if (empty($this->delegates) || empty($ctx) || empty($ctx->params))
 			throw new Exception('Unserviceable internal delegation attempt.', 501);
 
-		$path = implode('/', array_slice($ctx->params, 1));
+		$path = implode('/', $ctx->params);
 		foreach ($this->delegates as $p => $d) {
 			if (preg_match($p, $path)) {
 				if (empty($data)) return $this->$d($ctx);


### PR DESCRIPTION
A patch candidate for `master`. This represents undoing one change that was committed as part of the clean-up recently done to Presto 1.0. The change broke internal delegation. I have confirmed that undoing the change fixes the problems I noticed using the robotpony/Presto `master` branch from `app.rubrix.test`.

My plan is to merge the change from DSL/Presto into this branch and then point `app.rubrix.test` at this branch. I'll run like that for the time being. If I notice no further Presto problems in a few days then we can merge the `dsl-merge` branch into `master` and consider moving rubrix services to robotpony/Presto.
