### PR TITLE
Request::content_type requires the extension passed in (from original re...

### DIFF
--- a/lib/request.php
+++ b/lib/request.php
@@ -174,7 +174,7 @@ class Request {
 
 			if (empty($body)) return $decoded_body; // no data, not an error
 
-			switch ($this->content_type()) {
+			switch ($this->content_type($this->type)) {
 				case 'json':
 
 					if ( ! ($decoded_body = json_decode($body)) ) {


### PR DESCRIPTION
...quest URI), so I've added it to the call made in parsing out the payload body.

@bruce-alderson I noticed this the first time I tried to route a POST through that had a JSON body. I got an error about missing parameter for the content_type function.
