### PR TITLE
Issue 44

### DIFF
--- a/lib/response.php
+++ b/lib/response.php
@@ -1,4 +1,5 @@
 <?php
+include_once('encoders/html.php');
 
 /* A PrestoPHP HTTP response
 

--- a/lib/view.php
+++ b/lib/view.php
@@ -22,11 +22,9 @@ class View {
 
 		$this->d = array('dom' => $data); // namespaced into "dom"
 		$this->f = $view;
-
-		return $this->render();
 	}
 
-	protected function render() {
+	public function render() {
 		try {
 			// verify and load view
 


### PR DESCRIPTION
Fixes two small problems I noticed in attempting to return HTML from a `v4` API (uses Presto on `1.1-features`).

Tracked with #44.
