### PR TITLE
Surrounds db wrapper in a try/catch block

### DIFF
--- a/lib/db.php
+++ b/lib/db.php
@@ -104,7 +104,7 @@ class db extends PDO {
 		if (empty($e[0]) || $e[0] === self::DB_NO_ERR) return;
 		if (!empty($e[0]) && $e[0] === self::USR_DEF_DB_ERR) {
 			$msg = !empty($e[2]) ? $e[2] : 'Application defined SQL error occurred.';
-			throw new Exception($msg, 412);
+			throw new Exception($msg, 400);
 		}
 		else if (!empty($e[0]) && !empty($e[2])) {
 			throw new Exception($e[2], 500);


### PR DESCRIPTION
If `PDO::ERRMODE_EXCEPTION` is used, then the `execute()` function would throw an exception and we'd never run `$this->errors()`;

By surrounding `execute()` in a try/catch, we ensure that we always check the results using `errors()` on all PDO error level (silent, warnings, and exceptions).

**Note:**

This should be put on presto and presto 1.1: if this gets approved then I can re-create the pull request for the 1.1 branch.
