### PR TITLE
Fixes #49. Support for array parameters in PDO wrapper.

### DIFF
--- a/lib/db.php
+++ b/lib/db.php
@@ -35,6 +35,10 @@ class db extends PDO {
 
 	/* Returns an array of classes based on the given SQL and bound parameters (see PDO docs for details) */
 	function select($sql, $bound_parameters = array()) {
+	
+		// Expand any array parameters
+		$this->expand_select_params($sql, $bound_parameters);
+
 		$this->statement = $this->prepare($sql, array(PDO::ATTR_CURSOR => PDO::CURSOR_FWDONLY));
 		$this->statement->execute($bound_parameters);
 		$resultset = $this->statement->fetchAll(PDO::FETCH_CLASS);
@@ -61,6 +65,10 @@ class db extends PDO {
 		that parameter's PDO datatype.
 	 */
 	function query($sql, &$bound_parameters = array()) {
+	
+		// Expand any array parameters
+		$this->expand_query_params($sql, $bound_parameters);
+		
 		$this->statement = $this->prepare($sql);
 		if (!empty($bound_parameters)) {
 			foreach ($bound_parameters as $key => &$param) {
@@ -104,5 +112,106 @@ class db extends PDO {
 			throw new Exception($e[2], 500);
 		}
 		else throw new Exception('Update failed for unknown reason.', 500);
+	}
+	
+	/*
+		Utility: expand any parameters passed in as an array (as PDO does not yet support this).
+		
+		For any parameter `p => array( k1 => v1, k2 => v2, ..., kn => vn)` in `$params`,
+		`p` is expanded to `p_k1 => v1, p_k2 => v2, ..., p_kn => vn` all members of `$params`.
+		
+		For any label `:p` in `$sql`, `p` is replaced with `:p_k1, :p_k2, ..., :p_kn` in `$sql`.
+	*/
+	private function expand_select_params(&$sql, &$params) {
+
+		$expanded = array(); // store expanded parameters until we're done
+		$expandedKeys = array(); // store the keys of expanded arrays so we can unset them when we're done
+		
+		foreach ($params as $p => $arrayParam) {
+		
+			// only worry about non-empty arrays
+			if (!is_array($arrayParam) || empty($arrayParam)) continue;
+			
+			$expandedKeys[] = $p;
+			$names = ''; // list of labels `:p_k1, :p_k2, ..., :p_kn` with which to replace `:p` in $sql
+			foreach ($arrayParam as $k => $v) {
+			
+				// Ensure validity of members
+				if ((!empty($v) && !is_scalar($v))) {
+					$t = gettype($v);
+					throw new Exception("Array parameter expansion error: members of array '$p' must be scalars, but '$k' is a '$t'.", 500);
+				}
+				
+				$expanded["{$p}_{$k}"] = $v;
+				$names .= ":{$p}_{$k}, ";
+			}
+			
+			// replace :p in $sql with $names
+			$names = rtrim($names, " ,");
+			$sql = str_replace(":$p", $names, $sql);
+		}
+		
+		// Nothing expanded
+		if (empty($expandedKeys)) return;
+		
+		// Get rid of the now expanded array params
+		foreach ($expandedKeys as $v)
+			unset($params[$v]);
+			
+		// Merge in the expanded values
+		$params = array_merge($params, $expanded);
+	}
+	
+	/*
+		Utility: expand any parameters passed in as an array (as PDO does not yet support this).
+		
+		For any parameter `p => array('value' => array( k1 => v1, k2 => v2, ..., kn => vn), 'pdoType' => PDO::SOME_PDO_TYPE)` in `$params`,
+		`p` is expanded to 
+			`p_k1 => array('value' => v1, 'pdoType' => PDO::SOME_PDO_TYPE), 
+			p_k2 => array('value' => v2, 'pdoType' => PDO::SOME_PDO_TYPE), 
+			..., 
+			p_kn => array('value' => vn, 'pdoType' => PDO::SOME_PDO_TYPE)` 
+		all members of `$params`.
+		
+		For any label `:p` in `$sql`, `p` is replaced with `:p_k1, :p_k2, ..., :p_kn` in `$sql`.
+	*/
+	private function expand_query_params(&$sql, &$params) {
+
+		$expanded = array(); // store expanded parameters until we're done
+		$expandedKeys = array(); // store the keys of expanded arrays so we can unset them when we're done
+		
+		foreach ($params as $p => $arrayParam) {
+		
+			// only worry about non-empty arrays
+			if (!is_array($arrayParam['value']) || empty($arrayParam['value'])) continue;
+			
+			$expandedKeys[] = $p;
+			$names = ''; // list of labels `:p_k1, :p_k2, ..., :p_kn` with which to replace `:p` in $sql
+			foreach ($arrayParam['value'] as $k => $v) {
+			
+				// Ensure validity of members
+				if ((!empty($v) && !is_scalar($v))) {
+					$t = gettype($v);
+					throw new Exception("Array parameter expansion error: members of array '$p' must be scalars, but '$k' is a '$t'.", 500);
+				}
+				
+				$expanded["{$p}_{$k}"] = array('value' => $v, 'pdoType' => $arrayParam['pdoType']);
+				$names .= ":{$p}_{$k}, ";
+			}
+			
+			// replace :p in $sql with $names
+			$names = rtrim($names, " ,");
+			$sql = str_replace(":$p", $names, $sql);
+		}
+		
+		// Nothing expanded
+		if (empty($expandedKeys)) return;
+		
+		// Get rid of the now expanded array params
+		foreach ($expandedKeys as $v)
+			unset($params[$v]);
+			
+		// Merge in the expanded values
+		$params = array_merge($params, $expanded);
 	}
 }


### PR DESCRIPTION
We split queries into two types: `SELECT` queries and everything else. `SELECT` queries have parameters in the form `array(k1 => v1, ..., kn => vn)`. All other queries have parameters in the form: 

```
array(
    k1 => array('value' => v1, 'pdoType' => PDO::SOME_PDO_TYPE),
    ...,
    kn => array('value' => vn, 'pdoType' => PDO::SOME_PDO_TYPE)
)
```

This adds two private helper functions to the db wrapper to expand array parameters. One is used for the `SELECT` style paramaterization, the other for the other query style. 

**Note:** while these can be combined into a single function (I started with it that way) it was more elegant, and clearer, to split them up for the different cases.
