### PR TITLE
Type reset in db::select_objects()

### DIFF
--- a/lib/db.php
+++ b/lib/db.php
@@ -120,8 +120,7 @@ class db extends PDO {
 			        if (!isset($ptr[$k])) $ptr[$k] = array();
 			        $ptr = &$ptr[$k];
 			    }
-				error_log(print_r($type,1),3,"/tmp/debug.log");
-				error_log(print_r("\n",1),3,"/tmp/debug.log");
+
 
 				// adjust type if needed
 				if (!empty($type)) settype($value, $type);


### PR DESCRIPTION
`$type` wasn't being reset if it was undefined. This would cause the following errors:

```
SELECT 
    p.PersonID as 'ID:int',
    p.FirstName as 'name.first',
    p.MiddleName as 'name.middle',
```

**`int` cascades into strings, causing data removal**
![](https://www.evernote.com/shard/s229/sh/0eae91cd-1b01-4dfb-9cc9-f315cb9101b1/17c4386391d97f6e50ee17fd588fa5e8/deep/0/app.rubrix.test/v4/account/profile.json.png)

By resetting `$type` to `null` when it is undefined, we can prevent this:

![](https://www.evernote.com/shard/s229/sh/bedc570f-a8c9-4673-9ce4-0e28bf896a36/0d5b5364b8f3cd9029371b58fb96ebd8/deep/0/app.rubrix.test/v4/account/profile.json.png)
