### PR TITLE
Formats select_objects() data in json friendly way

### DIFF
--- a/lib/db.php
+++ b/lib/db.php
@@ -93,7 +93,7 @@ class db extends PDO {
 
 		$d = '.'; $t = ':'; // delimiters for depth and type
 		$o = array(); // output
-		
+
 		foreach ($rows as $r) { // each row in result set
 			
 			$row = array();
@@ -116,12 +116,10 @@ class db extends PDO {
 
 				// create objects as needed
 			    foreach ($keys as $k) {
-			    
+
 			        if (!isset($ptr[$k])) $ptr[$k] = array();
 			        $ptr = &$ptr[$k];
 			    }
-
-
 				// adjust type if needed
 				if (!empty($type)) settype($value, $type);
 				
@@ -133,7 +131,7 @@ class db extends PDO {
 			$o[] = $row; // add row to output
 		}
 
-		return $o;
+		return json_decode(json_encode($o));
 	}	
 
 	/* Provide a wrapper for updates which is really just an alias for the query function. */


### PR DESCRIPTION
This maintains consistency between API's and return data when using `select_objects()`. By ensuring the data is in JSON format, we can trust the validity of the object being returned.

**Example**

When running `select_objects()` I would get this structure back in PHP:

```
stdClass Object
(
    [ID] => 3025
    [name] => Array
        (
            [first] => Cora
            [middle] => Bo
            [last] => Bora
            [display] => Cora Bo Bora
        )
)
```

> This isn't in a valid JSON syntax yet - the name array would be converted to an object

But then when returning that object at the end of the api to presto, it would output to a client like this:

```
{
    "ID": 3025
    "name": {
        "first": "Cora"
        "middle": "Bo"
        "last": "Bora"
        "display": "Cora Bo Bora"
    }
}
```

> The above is correct JSON 

This is because presto ensures everything is JSON compatible. This caused some unpleasantness when writing API's, as you would have to reference things you were expecting to be objects as arrays:

**In the API**:

```
$var = $person->name['first'];
```

**With the data the API would return**:

```
$var = $person->name->first;
```

All I've done is formatted the return data of `select_objects` to follow the JSON structure. This made API writing much simpler, as I didn't have to fight what style I was writing things in.
