### PR TITLE
Adds a function to allow individual API paths to support CORS requests e...

### DIFF
--- a/lib/api.php
+++ b/lib/api.php
@@ -44,6 +44,26 @@ class API extends REST {
 		return $this->supports_contentType($types);
 	}
 
+	/* Set necessary CORS headers for this API route.
+	
+		* Sets `Access-Control-Allow-Origin` appropriately with respect to referer (necessary for `Access-Control-Allow-Credentials`)
+		* Sets `Access-Control-Allow-Credentials: true`: allow `rx-auth` cookie to be included in request (authentication)
+		* Sets `Access-Control-Allow-Methods: GET`: only GETs supported for now
+		* sets some other useful default headers
+
+	*/
+	public function crossOrigin() {
+	
+		if (empty($_SERVER['HTTP_ORIGIN']))
+			throw new Exception("'HTTP_ORIGIN' unknown. Failed to set required 'Access-Control-Allow-Origin' header for CORS handshake.", 500);
+			
+		$this->add_header('Access-Control-Allow-Origin', $_SERVER['HTTP_ORIGIN']);
+		$this->add_header('Access-Control-Allow-Credentials', 'true');
+		$this->add_header('Access-Control-Allow-Methods', 'GET');
+		$this->add_header('Access-Control-Allow-Headers', 'Content-Type,Accept');
+		$this->add_header('Access-Control-Max-Age', '10');
+	}
+
 	/* Get a filtered variable (get filter_var_array + exceptions) */
 	static function filtered($thing, $rules, $defaults = null) {
 		if ($defaults) $thing = array_merge($defaults, (array)$thing);


### PR DESCRIPTION
...asily. The function sets headers necessary to allow cookie based authentication (include cookies in CORS request). Currently restricted to GETs.

Argument for having one presto install in `app`:
1. I searched for the `api.php` file by searching for `restrictTo` in Coda (because I am lazy).
2. Found the file and implemented the function ... it didn't work.
3. Started hypothesizing reasons the approach was flawed: CORS handshake mystery, etc?
4. Stepped back from crazy and tried setting the necessary headers directly in my API ... works fine: the problem is me, not CORS mystery.
5. Realized I was working in the wrong file.

You could argue this is just me being dumb :smile:  but it is annoying to have to keep track of two presto installs in `app`.

@bruce-alderson for review

@ngallagher87 so he is aware of this
