### PR TITLE
Adding a more detailed error for PDO bindings

### DIFF
--- a/lib/db.php
+++ b/lib/db.php
@@ -248,6 +248,9 @@ class db extends PDO {
 		else if (!empty($e[0]) && !empty($e[2])) {
 			throw new Exception($e[2], 500);
 		}
+		else if (!empty($e[0]) && strcmp($e[0], 'HY093') === 0) {
+			throw new Exception('Error HY093: Check your PDO field bindings', 500);
+		}
 		else throw new Exception('Update failed for unknown reason.', 500);
 	}
 


### PR DESCRIPTION
Firstly, I'd like to point out that I screwed up the branch name... :sweat_smile: My bad.

---

This is a pretty simple addition - if a PDO binding error occurred, this outputs a more helpful error message.

Basically, `HY093` means that you don't have your binding values matched up to your SQL:

```
$sql = <<<SQL
    INSERT INTO Something VALUES (:thing, :coolerThing);
SQL;

$this->db->insert($sql, array('thing' => 'apple', 'coolerThng' => 'fighterJet'); // misspelled :coolerThing
```

Getting the `HY093` instead of the generic error (`Update failed for unknown reason.`) helps point out that you missed/misspelled a binding, and it also gives the user something to search.

This is just something that I've been using for the past month or so and it's helped speed debugging along in a few cases.
