### PR TITLE
Including a db wrapper function that will format PDO params for you

### DIFF
--- a/lib/db.php
+++ b/lib/db.php
@@ -236,6 +236,61 @@ class db extends PDO {
 	function affected_rows() {
 		return $this->statement->rowCount();
 	}
+	
+	/*
+		Generates a PDO bound parameterized array.
+		
+		Pass this an array of keys and values that you want to use in your DB query.
+		generate_params() will return you a valid PDO array to use with 
+		your INSERT and UPDATE statements.
+		
+		Supported types:
+		=================
+			PARAM_BOOL
+			PARAM_NULL
+			PARAM_INT
+			PARAM_STR
+		
+		Unsupported types:
+		=================
+			PARAM_LOB
+			PARAM_INPUT_OUTPUT
+			PARAM_STMT (No drivers support this anyways)
+		
+		Note:
+		
+			If you need to use one of these unsupported types, you'll have to
+			generate the params by hand.
+		
+		Example:
+		========
+		
+			$sql = <<<SQL
+				INSERT INTO Days (Day, DayNumber, isHoliday)
+				VALUES (:day, :dayNumber, :isHoliday);
+			SQL;
+			
+			$values = array(
+				'day' => 'tuesday', 
+				'dayNumber' => 2, 
+				'isHoliday' => true
+			);
+			$params = $this->db->generate_params($values);
+			$this->db->insert($sql, $params);
+	*/
+	public function generate_params($array) {
+		$params = array();
+		foreach ($array as $key => $val) {
+			$pdoType = PDO::PARAM_NULL;
+			if (is_numeric($val)) $pdoType = PDO::PARAM_INT;
+			else if (is_bool($val)) $pdoType = PDO::PARAM_BOOL;
+			else if (is_string($val)) $pdoType = PDO::PARAM_STR;
+			
+			$params[$key] = array('value' => $val, 'pdoType' => $pdoType);
+		}
+		return $params;
+	}
+	
 
 	/* Throw error info pertaining to the last operation. */
 	private function errors() {

--- a/lib/db.php
+++ b/lib/db.php
@@ -316,21 +316,17 @@ class db extends PDO {
 		Returns true if they are bound, and false if they are not.
 	*/
 	private function is_bound($array) {
-		$validate = function($key) {
-			return $key === 'pdoType';
-	 	};
+		$pdoTypes = array(PDO::PARAM_INT, PDO::PARAM_NULL, 
+							PDO::PARAM_BOOL, PDO::PARAM_STR);
 		foreach ($array as $key => $val) {
-			if (is_array($val)) {         
-				foreach ($val as $k => $v) {
-					if ($validate($k))
-						return true;
-	 			}
-			} else {
-				if ($validate($key))
-					return true;
-	 		}
+			if (is_array($val)) {     
+				if (!isset($val['pdoType']) ||
+					!in_array($val['pdoType'], $pdoTypes))
+					return false;
+			}
+			else return false;
 		}
-		return false;
+		return true;
 	}
 
 	/* Throw error info pertaining to the last operation. */

--- a/lib/db.php
+++ b/lib/db.php
@@ -137,6 +137,8 @@ class db extends PDO {
 
 	/* Provide a wrapper for updates which is really just an alias for the query function. */
 	function update($sql, $bound_parameters = array()) {
+		if (!is_bound($bound_parameters) 
+			$bound_parameters = generate_params($bound_parameters);
 		$this->query($sql, $bound_parameters);
 	}
 	/*
@@ -171,6 +173,8 @@ class db extends PDO {
 
 	/* Provide a wrapper for inserts which is really just an alias for the query function. */
 	function insert($sql, $bound_parameters = array()) {
+		if (!is_bound($bound_parameters) 
+			$bound_parameters = generate_params($bound_parameters);
 		$this->query($sql, $bound_parameters);
 		if ($this->statement->rowCount() === 0)
 			throw new Exception('Insert failed: no rows were inserted.', 409);
@@ -291,6 +295,17 @@ class db extends PDO {
 		return $params;
 	}
 	
+	/*
+		Tests to see if parameters have been bound or not.
+		Returns true if they are bound, and false if they are not.
+	*/
+	private function is_bound($array) {
+		foreach ($array as $key => $val) {
+			if (is_array($val)) 
+				return true;
+	 	}
+		return false;
+	}
 
 	/* Throw error info pertaining to the last operation. */
 	private function errors() {

--- a/lib/db.php
+++ b/lib/db.php
@@ -137,7 +137,7 @@ class db extends PDO {
 
 	/* Provide a wrapper for updates which is really just an alias for the query function. */
 	function update($sql, $bound_parameters = array()) {
-		if (!is_bound($bound_parameters) 
+		if (!is_bound($bound_parameters))
 			$bound_parameters = generate_params($bound_parameters);
 		$this->query($sql, $bound_parameters);
 	}
@@ -173,7 +173,7 @@ class db extends PDO {
 
 	/* Provide a wrapper for inserts which is really just an alias for the query function. */
 	function insert($sql, $bound_parameters = array()) {
-		if (!is_bound($bound_parameters) 
+		if (!is_bound($bound_parameters))
 			$bound_parameters = generate_params($bound_parameters);
 		$this->query($sql, $bound_parameters);
 		if ($this->statement->rowCount() === 0)

--- a/lib/db.php
+++ b/lib/db.php
@@ -137,8 +137,6 @@ class db extends PDO {
 
 	/* Provide a wrapper for updates which is really just an alias for the query function. */
 	function update($sql, $bound_parameters = array()) {
-		if (!$this->is_bound($bound_parameters))
-			$bound_parameters = $this->bind_parameters($bound_parameters);
 		$this->query($sql, $bound_parameters);
 	}
 	/*
@@ -149,7 +147,10 @@ class db extends PDO {
 		that parameter's PDO datatype.
 	 */
 	function query($sql, $bound_parameters = array()) {
-
+		// Check if the params have been bound or not already
+		if (!$this->is_bound($bound_parameters))
+			$bound_parameters = $this->bind_parameters($bound_parameters);
+			
 		// Expand any array parameters
 		$this->expand_query_params($sql, $bound_parameters);
 
@@ -173,8 +174,6 @@ class db extends PDO {
 
 	/* Provide a wrapper for inserts which is really just an alias for the query function. */
 	function insert($sql, $bound_parameters = array()) {
-		if (!$this->is_bound($bound_parameters))
-			$bound_parameters = $this->bind_parameters($bound_parameters);
 		$this->query($sql, $bound_parameters);
 		if ($this->statement->rowCount() === 0)
 			throw new Exception('Insert failed: no rows were inserted.', 409);

--- a/lib/db.php
+++ b/lib/db.php
@@ -12,8 +12,11 @@
 class db extends PDO {
 
 	private $statement;
+	private static $valid_pdo_types = array(PDO::PARAM_INT, PDO::PARAM_NULL, 
+									PDO::PARAM_BOOL, PDO::PARAM_STR);
 	const USR_DEF_DB_ERR 	= '45000';
 	const DB_NO_ERR 		= '00000';
+	
 
 
 	/* Create (or reuse) an instance of a PDO database */
@@ -313,14 +316,14 @@ class db extends PDO {
 	/*
 		Tests to see if parameters have been bound or not.
 		Returns true if they are bound, and false if they are not.
+		
+		An array is either bound or not - there are no partial cases.
 	*/
 	private function is_bound($array) {
-		$pdoTypes = array(PDO::PARAM_INT, PDO::PARAM_NULL, 
-							PDO::PARAM_BOOL, PDO::PARAM_STR);
 		foreach ($array as $key => $val) {
 			if (is_array($val)) {     
 				if (!isset($val['pdoType']) ||
-					!in_array($val['pdoType'], $pdoTypes))
+					!in_array($val['pdoType'], self::$valid_pdo_types))
 					return false;
 			}
 			else return false;

--- a/lib/db.php
+++ b/lib/db.php
@@ -137,8 +137,8 @@ class db extends PDO {
 
 	/* Provide a wrapper for updates which is really just an alias for the query function. */
 	function update($sql, $bound_parameters = array()) {
-		if (!is_bound($bound_parameters))
-			$bound_parameters = bind_parameters($bound_parameters);
+		if (!$this->is_bound($bound_parameters))
+			$bound_parameters = $this->bind_parameters($bound_parameters);
 		$this->query($sql, $bound_parameters);
 	}
 	/*
@@ -173,8 +173,8 @@ class db extends PDO {
 
 	/* Provide a wrapper for inserts which is really just an alias for the query function. */
 	function insert($sql, $bound_parameters = array()) {
-		if (!is_bound($bound_parameters))
-			$bound_parameters = bind_parameters($bound_parameters);
+		if (!$this->is_bound($bound_parameters))
+			$bound_parameters = $this->bind_parameters($bound_parameters);
 		$this->query($sql, $bound_parameters);
 		if ($this->statement->rowCount() === 0)
 			throw new Exception('Insert failed: no rows were inserted.', 409);


### PR DESCRIPTION
## PDO helper

I'm adding a function that makes it a bit easier to generate PDO parameters. 

**From this**

```
$params = array(
            'candy' => array('value' => $this->favoriteCandy, 'pdoType' => PDO::PARAM_STR),
            'person' => array('value' => $this->person, 'pdoType' => PDO::PARAM_INT)
        );
$this->db->insert($sql, $params);
```

**To this**

```
$params = array(
        'candy' => $this->favoriteCandy,
        'person' => $this->person
    );
$this->db->insert($sql, $params);
```

Pass this function an array of keys and values that you want to use in your DB query. When sending INSERT and UPDATE statements, `generate_params()` will run inside the db wrapper silently if the array passed is unbound.
# Supported types:

```
PARAM_BOOL
PARAM_NULL
PARAM_INT
PARAM_STR
```
# Unsupported types:

```
PARAM_LOB
PARAM_INPUT_OUTPUT
PARAM_STMT (No drivers support this anyways)
```

**Note:**

If you need to use one of these unsupported types, you'll have to generate the params by hand.
# Full Example:

```
$sql = <<<SQL
    INSERT INTO Days (Day, DayNumber, isHoliday)
    VALUES (:day, :dayNumber, :isHoliday);
SQL;

$values = array(
    'day' => 'tuesday', 
    'dayNumber' => 2, 
    'isHoliday' => true
);
$this->db->insert($sql, $values);
```
