### PR TITLE
Csv presto

### DIFF
--- a/lib/response.php
+++ b/lib/response.php
@@ -136,10 +136,8 @@ class Response {
 		if (array_key_exists($type, self::$type_handlers))
 			$h = self::$type_handlers[$type]; // direct mapping
 		else {
-			foreach (self::$type_handlers as $exp => $handler) {
-				if (preg_match("#$exp#", $type)) $h = self::$type_handlers[$exp]; // expression mapping	
-				error_log(print_r($exp,1),3,"/tmp/debug.log");
-				}
+			foreach (self::$type_handlers as $exp => $handler)
+				if (preg_match("#$exp#", $type)) $h = self::$type_handlers[$exp]; // expression mapping
 		}
 
 		if (!$h) throw new Exception('Unknown resource type: ' . $type, 500);


### PR DESCRIPTION
I recently needed to use CSV return type, but Presto didn't seem to support it. 

For one, its not a recognized MIME type, and the default case was returning content type as `application/csv`... this is incorrect according to RFC 4180:

> This RFC documents the format of comma separated values
>    (CSV) files and formally registers the "text/csv" MIME type for CSV
>    in accordance with RFC 2048 [1].
> 
> > [Source](http://tools.ietf.org/html/rfc4180#page-2)

I also registered a default type handler (similar to `text/plain` it just prints the `$dom`)
