### PR TITLE
Sets errmode in our db instantiation code

### DIFF
--- a/lib/db.php
+++ b/lib/db.php
@@ -29,6 +29,7 @@ class db extends PDO {
 
 		try {
 			 $_db = new db($dsn, $user, $password, $config);
+			 $_db->setAttribute(constant("PDO::ATTR_ERRMODE"), constant("PDO::ERRMODE_EXCEPTION"));
 		 } catch (Exception $e) {
 			throw new Exception("Failed to connect to database.", 500, $e);
 		 }


### PR DESCRIPTION
@bruce-alderson 

Sets a PDO attribute in our DB wrapper instead of requiring the caller to set it. Related to https://github.com/Discovery-Software/app.rubrix.com/issues/2079
