### PR TITLE
Adds the error mode attribute setting code that was recently added in 1....

### DIFF
--- a/lib/helpers/db.php
+++ b/lib/helpers/db.php
@@ -28,6 +28,7 @@ class db extends \PDO {
 
 		try {
 			 $_db = new db($dsn, $user, $password, $config);
+			 $_db->setAttribute(constant("PDO::ATTR_ERRMODE"), constant("PDO::ERRMODE_EXCEPTION"));
 		 } catch (\Exception $e) {
 			throw new \Exception("Failed to connect to database.", 500, $e);
 		 }


### PR DESCRIPTION
...1.

@bruce-alderson 

This just adds the same error code setting to the DB class that was added with this commit 20a6a289c6c4ff04e7bcb29219bb026e2e50ebe2

In the 1.1 branch (master)
